### PR TITLE
Change-default-settings

### DIFF
--- a/lua/fspectate/cl_init.lua
+++ b/lua/fspectate/cl_init.lua
@@ -10,13 +10,13 @@ local roamVelocity = Vector( 0 )
 -- Customizable vars
 local thirdPersonDistance = 100
 local showChams = false
-local showNames = true
 local showPlayerInfo = true
-local showHealth = true
+local showNames = true
+local showHealth = false
 local showBeams = false
 local showRank = false
 local showCrosshair = true
-local showWeaponName = true
+local showWeaponName = false
 
 -- Localized functions
 local isValid = IsValid


### PR DESCRIPTION
Disable some of the default on settings to be disabled by default. I see a lot of staff turning these off when they use f spectate. Might be good to just disable these by default.